### PR TITLE
 Add validation to Parent and Child fields

### DIFF
--- a/ParentForum.php
+++ b/ParentForum.php
@@ -107,8 +107,24 @@
                     </table>
                   <div class="row justify-content-center pt-4 pb-4">
                     <button id="previous" onClick="previousHandler()">Previous Page</button>&nbsp;&nbsp;
-                    <button id="generate" class="" name="generatePlan" type="submit" value="Generate Plan">Generate Plan</button>
+                    <button id="generate" class="" onClick="validateChildForm('txtInitials[]', 'txtBirthYear[]')" name="generatePlan" type="submit" value="Generate Plan">Generate Plan</button>
                   </div>
+
+                  <script>
+                    function validateChildForm(nameFields, birthFields) {
+                      for (var kid in nameFields.length) {
+                        console.log(kid)
+                        var initials = document.getElementsByName(nameFields)[kid].value;
+                        var birthYear = document.getElementsByName(birthFields)[kid].value;
+                        if (initials === "" || birthYear === "") {
+                          alert("Please fill in all required fields.");
+                        } else {
+                          // Add your logic to proceed with the form submission or other actions
+                          alert("Form submitted successfully!");
+                        }
+                      }
+                    }
+                  </script>
 
                   <script>
                         $(document).ready(function() {

--- a/ParentForum.php
+++ b/ParentForum.php
@@ -39,8 +39,25 @@
                     </div>
                 </div>
                 <div class="row justify-content-center pt-4 pb-4">
-                    <button id="next" onclick="nextHandler()">Next Page</button>
+                    <button id="next" onclick="validateParentAForm() ? nextHandler() : other()">Next Page</button>
                 </div>
+              <script>
+                function validateParentAForm() {
+                    var initials = document.getElementsByName("partASocial");
+                    var birthYear = document.getElementsByName("partyAEmail");
+                    if (initials === "" || birthYear === "") {
+                      alert("Please fill in all required fields.");
+                      return false;
+                    } else {
+                      // Add your logic to proceed with the form submission or other actions
+                      alert("Form submitted successfully!");
+                      return true;
+                    }
+                }
+                function other() {
+                  console.log("it is wrong")
+                }
+              </script>
             </div>
 
 

--- a/ParentForum.php
+++ b/ParentForum.php
@@ -8,29 +8,29 @@
                 <div class="form-group row p-3">
                     <div class="col-lg-6">
                         <label class="" hide="true" data-dm->First Name</label>
-                        <input type="text" class="form-control" name="partyAFirst" placeholder="First Name" data-placeholder-original="Full Legal Name">
+                        <input type="text" class="form-control" name="partyAFirst" placeholder="First Name" data-placeholder-original="Full Legal Name" required>
                     </div>
 
                     <div class="col-lg-6">
                         <label class="" hide="true" data-dm->Last Name</label>
-                        <input type="text" class="form-control" name="partyALast" placeholder="Last Name" data-placeholder-original="Full Legal Name">
+                        <input type="text" class="form-control" name="partyALast" placeholder="Last Name" data-placeholder-original="Full Legal Name" required>
                     </div>
                 </div>
 
                 <div class="form-group row p-3">
                     <label data-dm->Residence</label>
-                    <textarea name="partyAStreet" class="form-control" placeholder="Street Address, Apt, City, State, Zip Code" data-placeholder-original="Street Address, Apt, City, State, Zip Code"></textarea>
+                    <textarea name="partyAResidence" class="form-control" placeholder="Street Address, Apt, City, State, Zip Code" data-placeholder-original="Street Address, Apt, City, State, Zip Code" required></textarea>
                 </div>
 
                 <div class="form-group row p-3">
                     <div class="col-lg-4">
                         <label data-dm->Cell Phone</label>
-                        <input type="tel" name="partyACell" placeholder="808-888-8888" class="form-control" data-placeholder-original="808-888-8888">
+                        <input type="tel" name="partyACell" placeholder="808-888-8888" class="form-control" data-placeholder-original="808-888-8888" required>
                     </div>
 
                     <div class="col-lg-4">
                         <label class="" hide="true" data-dm->Email</label>
-                        <input type="email" name="partyAEmail" class="form-control" placeholder="Email Address" data-placeholder-original="Your Email Address">
+                        <input type="email" name="partyAEmail" class="form-control" placeholder="Email Address" data-placeholder-original="Your Email Address" required>
                     </div>
 
                     <div class="col-lg-4">
@@ -39,24 +39,21 @@
                     </div>
                 </div>
                 <div class="row justify-content-center pt-4 pb-4">
-                    <button id="next" onclick="validateParentAForm() ? nextHandler() : other()">Next Page</button>
+                    <button id="next"
+                            onclick="validateParentAForm() ? nextHandler() : null">
+                      Next Page</button>
                 </div>
               <script>
                 function validateParentAForm() {
-                    var initials = document.getElementsByName("partyASocial").values;
-                    console.log(initials)
-                    var birthYear = document.getElementsByName("partyAEmail");
-                    if (initials === "" || birthYear === "") {
-                      alert("Please fill in all required fields.");
-                      return false;
-                    } else {
-                      // Add your logic to proceed with the form submission or other actions
-                      alert("Form submitted successfully!");
-                      return true;
-                    }
-                }
-                function other() {
-                  console.log("it is wrong")
+                  const first = document.getElementsByName("partyAFirst")[0].value;
+                  const last = document.getElementsByName("partyALast")[0].value;
+                  const address = document.getElementsByName("partyAResidence")[0].value;
+                  const cell = document.getElementsByName("partyACell")[0].value;
+                  const email = document.getElementsByName("partyAEmail")[0].value;
+                  const ssn = document.getElementsByName("partyASocial")[0].value;
+                  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+
+                  return !(first === "" || last === "" || address === "" || cell === "" || email === "" || ssn === "") && emailRegex.test(email);
                 }
               </script>
             </div>
@@ -68,40 +65,56 @@
                 <div class="form-group row p-3">
                     <div class="col-lg-6">
                         <label class="" hide="true" data-dm->First Name</label>
-                        <input type="text" name="partyBFirst" class="form-control" placeholder="First Name" data-placeholder-original="Spouse's Full Legal Name">
+                        <input type="text" name="partyBFirst" class="form-control" placeholder="First Name" data-placeholder-original="Spouse's Full Legal Name" required>
                     </div>
 
                     <div class="col-lg-6">
                         <label class="" hide="true" data-dm->Last Name</label>
-                        <input type="text" name="partyBLast" class="form-control" placeholder="Last Name" data-placeholder-original="Spouse's Birth or Maiden Name">
+                        <input type="text" name="partyBLast" class="form-control" placeholder="Last Name" data-placeholder-original="Spouse's Birth or Maiden Name" required>
                     </div>
                 </div>
 
                 <div class="form-group row p-3">
                     <label data-dm->Residence</label>
-                    <textarea name=" " class="form-control" placeholder="Street Address, Apt, City, State, Zip Code" data-placeholder-original="Street Address, Apt, City, State, Zip Code"></textarea>
+                    <textarea name="partyBResidence" class="form-control" placeholder="Street Address, Apt, City, State, Zip Code" data-placeholder-original="Street Address, Apt, City, State, Zip Code" required></textarea>
                 </div>
 
                 <div class="form-group row p-4">
                     <div class="col-lg-4">
                         <label data-dm->Cell Phone</label>
-                        <input type="tel" name=" " placeholder="808-888-8888" class="form-control" data-placeholder-original="808-888-8888">
+                        <input type="tel" name="partyBCell" placeholder="808-888-8888" class="form-control" data-placeholder-original="808-888-8888" required>
                     </div>
 
                     <div class="col-lg-4">
                         <label class="" hide="true" data-dm->Email</label>
-                        <input type="email" name=" " placeholder="Email Address" class="form-control" data-placeholder-original="Spouse's Email Address">
+                        <input type="email" name="partyBEmail" placeholder="Email Address" class="form-control" data-placeholder-original="Spouse's Email Address" required>
                     </div>
 
                     <div class="col-lg-4">
                         <label class="" hide="true" data-dm->Last 4 Digits of Social Security Number</label>
-                        <input type="text" name=" " placeholder="Last 4 Digits of SSN" class="form-control" data-placeholder-original="Spouse's Last 4 Digits of Social Security Number">
+                        <input type="text" name="partyBSocial" placeholder="Last 4 Digits of SSN" class="form-control" data-placeholder-original="Spouse's Last 4 Digits of Social Security Number" required>
                     </div>
                 </div>
                 <div class="row justify-content-center pt-4 pb-4">
                     <button id="previous" onClick="previousHandler()">Previous Page</button> &nbsp;&nbsp;
-                    <button id="next" onclick="nextHandler()">Next Page</button>
+                    <button id="next" onclick="validateParentBForm() ? nextHandler() : null">Next Page</button>
                 </div>
+
+
+              <script>
+                function validateParentBForm() {
+                  const first = document.getElementsByName("partyBFirst")[0].value;
+                  const last = document.getElementsByName("partyBLast")[0].value;
+                  const address = document.getElementsByName("partyBResidence")[0].value;
+                  const cell = document.getElementsByName("partyBCell")[0].value;
+                  const email = document.getElementsByName("partyBEmail")[0].value;
+                  const ssn = document.getElementsByName("partyBSocial")[0].value;
+
+                  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+
+                  return !(first === "" || last === "" || address === "" || cell === "" || email === "" || ssn === "") && emailRegex.test(email);
+                }
+              </script>
             </div>
 
 
@@ -131,7 +144,6 @@
                   <script>
                     function validateChildForm(nameFields, birthFields) {
                       for (var kid in nameFields.length) {
-                        console.log(kid)
                         var initials = document.getElementsByName(nameFields)[kid].value;
                         var birthYear = document.getElementsByName(birthFields)[kid].value;
                         if (initials === "" || birthYear === "") {

--- a/ParentForum.php
+++ b/ParentForum.php
@@ -35,7 +35,7 @@
 
                     <div class="col-lg-4">
                         <label class="" hide="true" data-dm->Last 4 Digits of Social Security Number</label>
-                        <input type="text" name="paryASocial" placeholder="Last 4 Digits of SSN" class="form-control" data-placeholder-original="Last 4 Digits of Social Security Number">
+                        <input type="text" name="partyASocial" placeholder="Last 4 Digits of SSN" class="form-control" data-placeholder-original="Last 4 Digits of Social Security Number" required>
                     </div>
                 </div>
                 <div class="row justify-content-center pt-4 pb-4">
@@ -43,7 +43,8 @@
                 </div>
               <script>
                 function validateParentAForm() {
-                    var initials = document.getElementsByName("partASocial");
+                    var initials = document.getElementsByName("partyASocial").values;
+                    console.log(initials)
                     var birthYear = document.getElementsByName("partyAEmail");
                     if (initials === "" || birthYear === "") {
                       alert("Please fill in all required fields.");
@@ -144,27 +145,23 @@
                   </script>
 
                   <script>
-                        $(document).ready(function() {
-                            var html = '<tr><td><input class="form-control" type="text" name="txtInitials[]" required=""></td><td><input class="form-control" type="text" name="txtBirthYear[]" required=""></td><td><input class="btn btn-danger" type="button" name="remove" id="remove" value="Remove"></td></tr>';
+                    var html = '<tr><td><input class="form-control" type="text" name="txtInitials[]" required=""></td><td><input class="form-control" type="text" name="txtBirthYear[]" required=""></td><td><input class="btn btn-danger" type="button" name="remove" id="remove" value="Remove"></td></tr>';
 
-                            // remove max if don't want to have a cap on number of kids to add
-                            var max = 5;
+                    // remove max if don't want to have a cap on number of kids to add
+                    var max = 5;
 
-                            var x = 1;
-                            $("#add").click(function() {
-                                if (x <= max) {
-                                    $("#table_field").append(html);
-                                    x++;
-                                }
-
-                            });
-                            $("#table_field").on('click', '#remove', function() {
-                                $(this).closest('tr').remove();
-                                x--;
-                            });
-
-                        });
-                    </script>
+                    var x = 1;
+                    $("#add").click(function() {
+                      if (x <= max) {
+                        $("#table_field").append(html);
+                        x++;
+                      }
+                    });
+                    $("#table_field").on('click', '#remove', function() {
+                      $(this).closest('tr').remove();
+                      x--;
+                    });
+                  </script>
                 </div>
             </div>
         </div>

--- a/ParentForum.php
+++ b/ParentForum.php
@@ -131,28 +131,33 @@
 
 
                         <tr>
-                            <td><input class="form-control" type="text" name="txtInitials[]" required=""></td>
-                            <td><input class="form-control" type="text" name="txtBirthYear[]" required=""></td>
+                            <td><input class="form-control" type="text" name="childInitials" required=""></td>
+                            <td><input class="form-control" type="text" name="childBirthYears" required=""></td>
                             <td><input class="btn btn-warning" type="button" name="add" id="add" value="Add"></td>
                         </tr>
                     </table>
                   <div class="row justify-content-center pt-4 pb-4">
                     <button id="previous" onClick="previousHandler()">Previous Page</button>&nbsp;&nbsp;
-                    <button id="generate" class="" onClick="validateChildForm('txtInitials[]', 'txtBirthYear[]')" name="generatePlan" type="submit" value="Generate Plan">Generate Plan</button>
+                    <button id="huh" class="" onClick="validateChildForm()">
+<!--                            name="generatePlan" type="submit" value="Generate Plan">-->
+                      Generate Plan or ndont</button>
                   </div>
 
                   <script>
-                    function validateChildForm(nameFields, birthFields) {
-                      for (var kid in nameFields.length) {
-                        var initials = document.getElementsByName(nameFields)[kid].value;
-                        var birthYear = document.getElementsByName(birthFields)[kid].value;
-                        if (initials === "" || birthYear === "") {
-                          alert("Please fill in all required fields.");
-                        } else {
-                          // Add your logic to proceed with the form submission or other actions
-                          alert("Form submitted successfully!");
-                        }
-                      }
+                    function validateChildForm() {
+                      const initials = document.getElementsByName("childInitials")[0].values;
+                      const birthYears = document.getElementsByName("childBirthYears");
+                      console.log(initials)
+
+                      // for (var initial in initials) {
+                      //   const initialRegex = /^[a-zA-Z]+\.[a-zA-Z]$/;
+                      //   if (initials === "" || birthYear === "") && initialRegex.test(initials) {
+                      //     alert("Please check format of initials");
+                      //     return false;
+                      //   }
+                      // }
+
+                      return false;
                     }
                   </script>
 

--- a/ParentForum.php
+++ b/ParentForum.php
@@ -39,8 +39,7 @@
                     </div>
                 </div>
                 <div class="row justify-content-center pt-4 pb-4">
-                    <button id="next"
-                            onclick="validateParentAForm() ? nextHandler() : null">
+                    <button id="next" onclick="validateParentAForm() ? nextHandler() : null">
                       Next Page</button>
                 </div>
               <script>
@@ -131,38 +130,47 @@
 
 
                         <tr>
-                            <td><input class="form-control" type="text" name="childInitials" required=""></td>
-                            <td><input class="form-control" type="text" name="childBirthYears" required=""></td>
+                            <td><input class="form-control" type="text" name="childInitials" required></td>
+                            <td><input class="form-control" type="text" name="childBirthYears" required></td>
                             <td><input class="btn btn-warning" type="button" name="add" id="add" value="Add"></td>
                         </tr>
                     </table>
                   <div class="row justify-content-center pt-4 pb-4">
                     <button id="previous" onClick="previousHandler()">Previous Page</button>&nbsp;&nbsp;
-                    <button id="huh" class="" onClick="validateChildForm()">
-<!--                            name="generatePlan" type="submit" value="Generate Plan">-->
-                      Generate Plan or ndont</button>
+                    <button id="generate" onClick="validateChildForm() ? submitForm() : null" class="" name="generatePlan" type="button" value="Generate Plan">Generate Plan</button>
                   </div>
 
                   <script>
+                    function submitForm() {
+                      //change the type attribute which will then send the form data over
+                      document.getElementsByName("generatePlan")[0].attributes[4].value = "submit";
+                    }
+
                     function validateChildForm() {
-                      const initials = document.getElementsByName("childInitials")[0].values;
+                      const initials = document.getElementsByName("childInitials");
                       const birthYears = document.getElementsByName("childBirthYears");
-                      console.log(initials)
+                      const initialRegex = /^[a-zA-Z]+\.[a-zA-Z]$/;
+                      const birthYearRegex = /^[0-9]{4}$/;
 
-                      // for (var initial in initials) {
-                      //   const initialRegex = /^[a-zA-Z]+\.[a-zA-Z]$/;
-                      //   if (initials === "" || birthYear === "") && initialRegex.test(initials) {
-                      //     alert("Please check format of initials");
-                      //     return false;
-                      //   }
-                      // }
-
-                      return false;
+                      for (let i = 0; i < initials.length; i++) {
+                        if (initials[i].value === "" || birthYears[i].value === "") {
+                          return false;
+                        }
+                        if (!initialRegex.test(initials[i].value)) {
+                          alert("Please check format of initials");
+                          return false;
+                        }
+                        if (!birthYearRegex.test(birthYears[i].value)) {
+                          alert("Please check format of birth years");
+                          return false;
+                        }
+                      }
+                      return true;
                     }
                   </script>
 
                   <script>
-                    var html = '<tr><td><input class="form-control" type="text" name="txtInitials[]" required=""></td><td><input class="form-control" type="text" name="txtBirthYear[]" required=""></td><td><input class="btn btn-danger" type="button" name="remove" id="remove" value="Remove"></td></tr>';
+                    var html = '<tr><td><input class="form-control" type="text" name="childInitials" required></td><td><input class="form-control" type="text" name="childBirthYears" required></td><td><input class="btn btn-danger" type="button" name="remove" id="remove" value="Remove"></td></tr>';
 
                     // remove max if don't want to have a cap on number of kids to add
                     var max = 5;

--- a/scripts/pagination.js
+++ b/scripts/pagination.js
@@ -16,7 +16,6 @@ function nextHandler() {
     pageCount = (pageCount + 1) % numPages;
     current = $("#page" + pageCount);
     current.removeClass("hidden");
-    console.log(pageCount);
 };
 
 function previousHandler() {
@@ -24,6 +23,5 @@ function previousHandler() {
     pageCount = pageCount > 0 ? (pageCount - 1) % numPages : numPages - 1;
     current = $("#page" + pageCount);
     current.removeClass("hidden");
-    console.log(pageCount);
 };
  


### PR DESCRIPTION
The form will now require all fields to be filled out in Section 1: Introduction.

- checks the email format for both Parent parties
- checks all of the initials format for children (allows for x amt of characters before the . but will only allow one character after the .)
- checks all of the birth years format for children (must consist of four numbers 0-9, inclusive)

Will need to separate the pages into separate forms because using the nextPage() function will try to validate all of the other fields. This is why the warning to fill out a field will show up before the user is on that page.
EX: filled out the PartyA form and clicked the Next Page button, the first name field on the PartyB form will show that it must be filled out. 
Since we don't want this, we will need to separate the forms, which means we will also need to adjust how the document is filled (multiple forms rather than just one).
