### PR TITLE
Disable the navbar items and only provide a way to go to the next section

### DIFF
--- a/Index.php
+++ b/Index.php
@@ -16,48 +16,74 @@ function console_log($output, $with_script_tags = true)
     }
     echo $js_code;
 }
-
+if(isset($_SESSION['canSeeParties'])) {
+    $_SESSION['canSeeParties'] = true;
+}
 if(isset($_SESSION['canSeeChildren'])) {
     $_SESSION['canSeeChildren'] = false;
-    console_log('settign false');
 }
-    console_log($_SESSION);
+if(!isset($_SESSION['canSeeCustody'])) {
+    $_SESSION['canSeeCustody'] = false;
+}
+if(!isset($_SESSION['canSeeTimesharing'])) {
+    $_SESSION['canSeeTimesharing'] = false;
+}
+if(!isset($_SESSION['canSeeCommunication'])) {
+    $_SESSION['canSeeCommunication'] = false;
+}
+if(!isset($_SESSION['canSeeSupport'])) {
+    $_SESSION['canSeeSupport'] = false;
+}
+if(!isset($_SESSION['canSeeIssues'])) {
+    $_SESSION['canSeeIssues'] = false;
+}
+if(!isset($_SESSION['canSeeLegal'])) {
+    $_SESSION['canSeeLegal'] = false;
+}
 // create an object that will serve as our database.
 $db = new Database;
-$_SESSION['page'] = isset($_GET['page']) ?$_GET['page'] : 1 ;
-if(isset($_SESSION['page'])){
-    $_SESSION['page'] = 1;
-}
-console_log($_SESSION['page']);
-require_once("views/Header.php");
-switch($_SESSION['page'])
+$page = $_GET['page'] ?? 1;
+console_log($page);
+switch($page)
 {
     case 1:
+        //values that determine if a nav item can be clicked on
+        require("views/Header.php");
         require_once("views/Parties.php");
         break;
     case 2:
+        $_SESSION['canSeeParties'] = true;
+        require("views/Header.php");
         require_once("views/Children.php");
         break;
     case 3:
+        $_SESSION['canSeeChildren'] = true;
+        require("views/Header.php");
         require_once("views/Custody.php");
         break;
     case 4:
+        $_SESSION['canSeeCustody'] = true;
+        require("views/Header.php");
         require_once("views/Timesharing.php");
-        //values that determine if a nav item can be clicked on
-        $_SESSION['canSeeChildren'] = true;
-        console_log("setting true in index");
-        console_log($_SESSION);
         break;
     case 5:
+        $_SESSION['canSeeTimesharing'] = true;
+        require("views/Header.php");
         require_once("views/Communication.php");
         break;
     case 6:
+        $_SESSION['canSeeCommunication'] = true;
+        require("views/Header.php");
         require_once("views/ChildSupport.php");
         break;
     case 7:
+        $_SESSION['canSeeSupport'] = true;
+        require("views/Header.php");
         require_once("views/Other.php");
         break;
     case 8:
+        $_SESSION['canSeeIssues'] = true;
+        require("views/Header.php");
         require_once("views/Legal.php");
         break;
     case 9:

--- a/Index.php
+++ b/Index.php
@@ -48,7 +48,7 @@ switch($page)
 {
     case 1:
         //values that determine if a nav item can be clicked on
-        require("views/Header.php");
+        require_once("views/Header.php");
         require_once("views/Parties.php");
         break;
     case 2:

--- a/Index.php
+++ b/Index.php
@@ -7,6 +7,7 @@ if(isset($_POST)) {
     $_SESSION['responses'] = array_replace($_SESSION['responses'], $_POST);
 }
 require_once("MysqlUtil.php");
+//delete this later: use for convenience
 function console_log($output, $with_script_tags = true)
 {
     $js_code = 'console.log(' . json_encode($output, JSON_HEX_TAG) .
@@ -16,10 +17,11 @@ function console_log($output, $with_script_tags = true)
     }
     echo $js_code;
 }
-if(isset($_SESSION['canSeeParties'])) {
+//initialize session variables
+if(!isset($_SESSION['canSeeParties'])) {
     $_SESSION['canSeeParties'] = true;
 }
-if(isset($_SESSION['canSeeChildren'])) {
+if(!isset($_SESSION['canSeeChildren'])) {
     $_SESSION['canSeeChildren'] = false;
 }
 if(!isset($_SESSION['canSeeCustody'])) {
@@ -43,16 +45,14 @@ if(!isset($_SESSION['canSeeLegal'])) {
 // create an object that will serve as our database.
 $db = new Database;
 $page = $_GET['page'] ?? 1;
-console_log($page);
 switch($page)
 {
     case 1:
         //values that determine if a nav item can be clicked on
-        require_once("views/Header.php");
+        require("views/Header.php");
         require_once("views/Parties.php");
         break;
     case 2:
-        $_SESSION['canSeeParties'] = true;
         require("views/Header.php");
         require_once("views/Children.php");
         break;

--- a/Index.php
+++ b/Index.php
@@ -1,19 +1,36 @@
 <?php
 session_start();
-if(!isset($_SESSION['responses']))
-{
-$_SESSION['responses'] = array();
+if(!isset($_SESSION['responses'])) {
+    $_SESSION['responses'] = array();
 }
-if(isset($_POST))
-{
-$_SESSION['responses'] = array_replace($_SESSION['responses'], $_POST);
+if(isset($_POST)) {
+    $_SESSION['responses'] = array_replace($_SESSION['responses'], $_POST);
 }
 require_once("MysqlUtil.php");
+function console_log($output, $with_script_tags = true)
+{
+    $js_code = 'console.log(' . json_encode($output, JSON_HEX_TAG) .
+        ');';
+    if ($with_script_tags) {
+        $js_code = '<script>' . $js_code . '</script>';
+    }
+    echo $js_code;
+}
+
+if(isset($_SESSION['canSeeChildren'])) {
+    $_SESSION['canSeeChildren'] = false;
+    console_log('settign false');
+}
+    console_log($_SESSION);
 // create an object that will serve as our database.
 $db = new Database;
-$page = isset($_GET['page']) ?$_GET['page'] : 1 ;
+$_SESSION['page'] = isset($_GET['page']) ?$_GET['page'] : 1 ;
+if(isset($_SESSION['page'])){
+    $_SESSION['page'] = 1;
+}
+console_log($_SESSION['page']);
 require_once("views/Header.php");
-switch($page)
+switch($_SESSION['page'])
 {
     case 1:
         require_once("views/Parties.php");
@@ -26,6 +43,10 @@ switch($page)
         break;
     case 4:
         require_once("views/Timesharing.php");
+        //values that determine if a nav item can be clicked on
+        $_SESSION['canSeeChildren'] = true;
+        console_log("setting true in index");
+        console_log($_SESSION);
         break;
     case 5:
         require_once("views/Communication.php");

--- a/Views/Header.php
+++ b/Views/Header.php
@@ -44,17 +44,23 @@ if(!session_id()) session_start();
 
                 <li class="nav-item"><a class="nav-link" href="./?page=1">Section 1: <br /> Parties </a></li>
               <?php
-                  $canSeeChildren = $_SESSION['canSeeChildren'];
-                  console_log("should be false at first");
-                  console_log($_SESSION['canSeeChildren']);
-                if ($canSeeChildren) {
-                    echo '<a href="javascript:void(0);">IT WAS TRUE</a>';
+                if ($_SESSION['canSeeChildren']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=2" aria-disabled="true">Section 2: <br /> Children </a></li>';
                 } else {
-                    echo '<li class="nav-item"><a class="nav-link" href="./?page=2" aria-disabled="true">Section 2: <br /> FALSE </a></li>';
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 2: <br /> Children </a></li>';
                 }
+              if ($_SESSION['canSeeCustody']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=3" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+              } else {
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+              }
+              if ($_SESSION['canSeeTimesharing']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=4" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+              } else {
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+              }
+
               ?>
-                <li class="nav-item"><a class="nav-link" href="./?page=3"> Section 3: <br /> Legal Custody </a></li>
-                <li class="nav-item"><a class="nav-link" href="<?php if(!isset($_SESSION['page'])){$_SESSION['page'] = 25;} else {$_SESSION['page'] = 4;} ?>"> Section 4: <br /> Physical Custody and Timesharing </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=5"> Section 5: <br /> Communication </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=6"> Section 6: <br /> Support of the Child(ren) </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=7"> Section 7: <br /> Other Issues </a></li>

--- a/Views/Header.php
+++ b/Views/Header.php
@@ -1,6 +1,3 @@
-<?php
-if(!session_id()) session_start();
-?>
 <!doctype html>
 <html lang="en">
 
@@ -42,43 +39,43 @@ if(!session_id()) session_start();
 
             <ul class="navbar-nav text-center">
 
-                <li class="nav-item"><a class="nav-link" href="./?page=1">Section 1: <br /> Parties </a></li>
+                <li class="nav-item"><a class="nav-link active-link" href="./?page=1">Section 1: <br /> Parties </a></li>
               <?php
                 if ($_SESSION['canSeeChildren']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=2" aria-disabled="true">Section 2: <br /> Children </a></li>';
+                  echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=2" aria-disabled="true">Section 2: <br /> Children </a></li>';
                 } else {
                     echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 2: <br /> Children </a></li>';
                 }
                 if ($_SESSION['canSeeCustody']) {
-                    echo '<li class="nav-item"><a class="nav-link" href="./?page=3" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=3" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
                 } else {
                     echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
                 }
                 if ($_SESSION['canSeeTimesharing']) {
-                    echo '<li class="nav-item"><a class="nav-link" href="./?page=4" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=4" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
                 } else {
                     echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
                 }
-              if ($_SESSION['canSeeCommunication']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=5" aria-disabled="true">Section 5: <br /> Communication </a></li>';
-              } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 5: <br /> Communication </a></li>';
-              }
-              if ($_SESSION['canSeeSupport']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=6" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
-              } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
-              }
-              if ($_SESSION['canSeeIssues']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=7" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
-              } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
-              }
-              if ($_SESSION['canSeeLegal']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=8" aria-disabled="true">Section 8: <br /> Legal </a></li>';
-              } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 8: <br /> Legal </a></li>';
-              }
+                if ($_SESSION['canSeeCommunication']) {
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=5" aria-disabled="true">Section 5: <br /> Communication </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 5: <br /> Communication </a></li>';
+                }
+                if ($_SESSION['canSeeSupport']) {
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=6" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
+                }
+                if ($_SESSION['canSeeIssues']) {
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=7" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
+                }
+                if ($_SESSION['canSeeLegal']) {
+                    echo '<li class="nav-item"><a class="nav-link active-link" href="./?page=8" aria-disabled="true">Section 8: <br /> Legal </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 8: <br /> Legal </a></li>';
+                }
               ?>
             </ul>
         </nav>

--- a/Views/Header.php
+++ b/Views/Header.php
@@ -23,7 +23,7 @@ if(!session_id()) session_start();
 <div id="wrapper">
     <header>
         <div class="container-fluid">
-            <div class="row color1 h-25 p-4">
+            <div class="row color1 p-4">
                 <div class="offset-md-5">
                     <div class="container1">
                         <div class="center" style="padding-right: 38vh">
@@ -49,22 +49,37 @@ if(!session_id()) session_start();
                 } else {
                     echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 2: <br /> Children </a></li>';
                 }
-              if ($_SESSION['canSeeCustody']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=3" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+                if ($_SESSION['canSeeCustody']) {
+                    echo '<li class="nav-item"><a class="nav-link" href="./?page=3" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+                }
+                if ($_SESSION['canSeeTimesharing']) {
+                    echo '<li class="nav-item"><a class="nav-link" href="./?page=4" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+                }
+              if ($_SESSION['canSeeCommunication']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=5" aria-disabled="true">Section 5: <br /> Communication </a></li>';
               } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 3: <br /> Legal Custody </a></li>';
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 5: <br /> Communication </a></li>';
               }
-              if ($_SESSION['canSeeTimesharing']) {
-                  echo '<li class="nav-item"><a class="nav-link" href="./?page=4" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+              if ($_SESSION['canSeeSupport']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=6" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
               } else {
-                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 4: <br /> Physical Custody and Timesharing </a></li>';
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 6: <br /> Support of the Child(ren) </a></li>';
               }
-
+              if ($_SESSION['canSeeIssues']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=7" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
+              } else {
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 7: <br /> Other Issues </a></li>';
+              }
+              if ($_SESSION['canSeeLegal']) {
+                  echo '<li class="nav-item"><a class="nav-link" href="./?page=8" aria-disabled="true">Section 8: <br /> Legal </a></li>';
+              } else {
+                  echo '<li class="nav-item"><a class="nav-link" aria-disabled="true">Section 8: <br /> Legal </a></li>';
+              }
               ?>
-                <li class="nav-item"><a class="nav-link" href="./?page=5"> Section 5: <br /> Communication </a></li>
-                <li class="nav-item"><a class="nav-link" href="./?page=6"> Section 6: <br /> Support of the Child(ren) </a></li>
-                <li class="nav-item"><a class="nav-link" href="./?page=7"> Section 7: <br /> Other Issues </a></li>
-                <li class="nav-item"><a class="nav-link" href="./?page=8"> Section 8: <br /> Legal </a></li>
             </ul>
         </nav>
     </header>

--- a/Views/Header.php
+++ b/Views/Header.php
@@ -1,3 +1,6 @@
+<?php
+if(!session_id()) session_start();
+?>
 <!doctype html>
 <html lang="en">
 
@@ -40,9 +43,18 @@
             <ul class="navbar-nav text-center">
 
                 <li class="nav-item"><a class="nav-link" href="./?page=1">Section 1: <br /> Parties </a></li>
-                <li class="nav-item"><a class="nav-link" href="./?page=2"> Section 2: <br /> Children </a></li>
+              <?php
+                  $canSeeChildren = $_SESSION['canSeeChildren'];
+                  console_log("should be false at first");
+                  console_log($_SESSION['canSeeChildren']);
+                if ($canSeeChildren) {
+                    echo '<a href="javascript:void(0);">IT WAS TRUE</a>';
+                } else {
+                    echo '<li class="nav-item"><a class="nav-link" href="./?page=2" aria-disabled="true">Section 2: <br /> FALSE </a></li>';
+                }
+              ?>
                 <li class="nav-item"><a class="nav-link" href="./?page=3"> Section 3: <br /> Legal Custody </a></li>
-                <li class="nav-item"><a class="nav-link" href="./?page=4"> Section 4: <br /> Physical Custody and Timesharing </a></li>
+                <li class="nav-item"><a class="nav-link" href="<?php if(!isset($_SESSION['page'])){$_SESSION['page'] = 25;} else {$_SESSION['page'] = 4;} ?>"> Section 4: <br /> Physical Custody and Timesharing </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=5"> Section 5: <br /> Communication </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=6"> Section 6: <br /> Support of the Child(ren) </a></li>
                 <li class="nav-item"><a class="nav-link" href="./?page=7"> Section 7: <br /> Other Issues </a></li>

--- a/scripts/pagination.js
+++ b/scripts/pagination.js
@@ -4,27 +4,23 @@ let current;
 $(document).ready(function () {
     current = $("#page" + pageCount);
     let elements = $("#mainForm").children();
-    console.log(elements);
     numPages = elements.length;
     //hide everything
     elements.addClass("hidden");
     current.removeClass("hidden");
-
 });
 
 function nextHandler() {
-  console.log(pageCount)
     current.addClass("hidden");
     pageCount = (pageCount + 1) % numPages;
     current = $("#page" + pageCount);
     current.removeClass("hidden");
-  console.log("after" + pageCount)
-};
+}
 
 function previousHandler() {
     current.addClass("hidden");
     pageCount = pageCount > 0 ? (pageCount - 1) % numPages : numPages - 1;
     current = $("#page" + pageCount);
     current.removeClass("hidden");
-};
+}
  


### PR DESCRIPTION
Nav items are now disabled until the user has successfully passed that section. EX: Children section cannot be clicked on until the user has completed the previous form (Parties section) and completed the Children section as well. 

Going back to a section will appear to have lost the data currently. Discussing with the team now if we would like to change our business logic (I would be able to use the session variables as a way to hydrate the previous forms).

EDIT: I added a console_log function for convenience printing in PHP files. Will need to delete it later.

For issue #29.