### PR TITLE
Fix childBirthdays bug

### DIFF
--- a/documentGenerators/DocumentGenerator.php
+++ b/documentGenerators/DocumentGenerator.php
@@ -206,7 +206,8 @@ abstract class documentGenerator
         /** Section 2: Children. */
         $childNum = 1;
         for ($i  = 2; $i <= 6; $i++) {
-            if (isset($_SESSION['responses']['child' . $i . 'Initials']) && isset($_SESSION['responses']['child' . $i . 'Birthday'])) {
+            if (($_SESSION['responses']['child' . $i . 'Initials'] != "") && ($_SESSION['responses']['child' . $i . 'Birthday'] != "")) {
+                console_log($_SESSION['responses']['child' . $i . 'Initials']);
                 $childNum++;
             }
         }

--- a/documentGenerators/HolidayTable.php
+++ b/documentGenerators/HolidayTable.php
@@ -1,6 +1,6 @@
 <?php
 class HolidayTable {
-    public function getHolidayTable(string $parentABirthday, string $parentBBirthday, string $childBirthday): string {
+    public function getHolidayTable(string $parentABirthday, string $parentBBirthday): string {
         return "<p class=MsoNormal style='margin-top:0in;margin-right:1.8pt;margin-bottom:.05pt;
             margin-left:0in;text-align:justify;text-indent:1.5in;line-height:150%'><u><span
              style='text-decoration:none'>&nbsp;</span></u></p>
@@ -186,16 +186,22 @@ class HolidayTable {
               margin-left:0in;text-align:justify;text-indent:0in;line-height:150%'>Parent
               B's Birthday [$parentBBirthday]</p>
               </td>
-             </tr>
-             <tr>
+             </tr>";
+    }
+
+    public function getChildren(string $childXInitials, string $childXBirthday): string {
+        return "<tr>
               <td width=623 valign=top style='width:467.5pt;border:solid black 1.0pt;
               border-top:none;padding:0in 5.4pt 0in 5.4pt'>
               <p class=MsoNormal style='margin-top:0in;margin-right:0in;margin-bottom:.05pt;
-              margin-left:0in;text-align:justify;text-indent:0in;line-height:150%'>Child(ren)'s
-              Birthday(s) [$childBirthday]</p>
+              margin-left:0in;text-align:justify;text-indent:0in;line-height:150%'>$childXInitials's
+              Birthday [$childXBirthday]</p>
               </td>
-             </tr>
-             <tr>
+             </tr>";
+    }
+
+    public function getEnd(): string {
+        return "<tr>
               <td width=623 valign=top style='width:467.5pt;border:solid black 1.0pt;
               border-top:none;padding:0in 5.4pt 0in 5.4pt'>
               <p class=MsoNormal style='margin-top:0in;margin-right:0in;margin-bottom:.05pt;

--- a/documentGenerators/HolidayTableWord.php
+++ b/documentGenerators/HolidayTableWord.php
@@ -1,6 +1,6 @@
 <?php
 class HolidayTableWord {
-    public function getHolidayTable(string $parentABirthday, string $parentBBirthday, string $childBirthday): string {
+    public function getHolidayTable(string $parentABirthday, string $parentBBirthday): string {
         return "<w:p w14:paraId='56C2C2E5' w14:textId='77777777' w:rsidR='00505307' w:rsidRDefault='00505307'>
       <w:pPr>
         <w:spacing w:after='1' w:line='360' w:lineRule='auto'/>
@@ -493,8 +493,12 @@ class HolidayTableWord {
             </w:r>
           </w:p>
         </w:tc>
-      </w:tr>
-      <w:tr w:rsidR='00505307' w14:paraId='601CB9F9' w14:textId='77777777'>
+      </w:tr>";
+    }
+    
+    public function getChildren(string $childXInitials, string $childXBirthday): string
+    {
+        return "<w:tr w:rsidR='00505307' w14:paraId='601CB9F9' w14:textId='77777777'>
         <w:tc>
           <w:tcPr>
             <w:tcW w:w='9350' w:type='dxa'/>
@@ -506,12 +510,15 @@ class HolidayTableWord {
               <w:jc w:val='both'/>
             </w:pPr>
             <w:r>
-              <w:t>Child(ren)’s Birthday(s) [$childBirthday]</w:t>
+              <w:t>$childXInitials ’s Birthday(s) [$childXBirthday]</w:t>
             </w:r>
           </w:p>
         </w:tc>
-      </w:tr>
-      <w:tr w:rsidR='00505307' w14:paraId='24CEA8D2' w14:textId='77777777'>
+      </w:tr>";
+    }
+
+    public function getEnd(): string {
+      return "<w:tr w:rsidR='00505307' w14:paraId='24CEA8D2' w14:textId='77777777'>
         <w:tc>
           <w:tcPr>
             <w:tcW w:w='9350' w:type='dxa'/>

--- a/documentGenerators/HtmlGenerator.php
+++ b/documentGenerators/HtmlGenerator.php
@@ -1168,8 +1168,19 @@ class HtmlGenerator extends documentGenerator
     // Holiday Table.
     function gen_physical_custody_timesharing_6_03() {
         $table = new HolidayTable();
-        $holidayTable = $table->getHolidayTable($this->responses['partyABirthday'], $this->responses['partyBBirthday'], $this->responses['childBirthdays']);
+        $holidayTable = $table->getHolidayTable($this->responses['partyABirthday'], $this->responses['partyBBirthday']);
+        $childrenRows = $table->getChildren($this->responses['child1Initials'], $this->responses['child1Birthday']);
+        for ($i = 2; $i <= 6; $i++) {
+            $initials = $this->responses['child' . $i . 'Initials'];
+            $birthday = $this->responses['child' . $i . 'Birthday'];
+            if ($initials != "" && $birthday != "") {
+                $childrenRows .= $table->getChildren($initials, $birthday);
+            }
+        }
+        $end = $table->getEnd();
         echo $holidayTable;
+        echo $childrenRows;
+        echo $end;
         $this->fileContentString .= $holidayTable;
     }
     // Alternate Yearly.

--- a/documentGenerators/WordDocGenerator.php
+++ b/documentGenerators/WordDocGenerator.php
@@ -1383,8 +1383,19 @@ class wordDocGenerator extends documentGenerator
     }
     function gen_physical_custody_timesharing_6_03() {
         $table = new HolidayTableWord();
-        $holidayTable = $table->getHolidayTable($this->responses['partyABirthday'], $this->responses['partyBBirthday'], $this->responses['childBirthdays']);
+        $holidayTable = $table->getHolidayTable($this->responses['partyABirthday'], $this->responses['partyBBirthday']);
+        $childrenRows = $table->getChildren($this->responses['child1Initials'], $this->responses['child1Birthday']);
+        for ($i = 2; $i <= 6; $i++) {
+            $initials = $this->responses['child' . $i . 'Initials'];
+            $birthday = $this->responses['child' . $i . 'Birthday'];
+            if ($initials != "" && $birthday != "") {
+                $childrenRows .= $table->getChildren($initials, $birthday);
+            }
+        }
+        $end = $table->getEnd();
         echo $holidayTable;
+        echo $childrenRows;
+        echo $end;
         $this->fileContentString .= $holidayTable;
     }
     function gen_physical_custody_timesharing_6_03A() {


### PR DESCRIPTION
Changed logic in both HtmlGen and WordDocGen to enable dynamic number of children in the Holidays Table in the final output. Right now, `getEnd()` will output an additional three rows in the Holiday Table but can be removed easily. Will be up to our sponsor's decision.